### PR TITLE
Add WorkingDirectory option

### DIFF
--- a/templates/etc/systemd/system/cerebro.service
+++ b/templates/etc/systemd/system/cerebro.service
@@ -3,6 +3,7 @@ Description=Cerebro: Elasticsearch web admin tool
 Documentation=https://github.com/lmenezes/cerebro
 
 [Service]
+WorkingDirectory=/opt/cerebro
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=/opt/cerebro/bin/cerebro -Dconfig.file=/etc/cerebro/application.conf


### PR DESCRIPTION
Add WorkingDirectory option to systemd unit file.

This fixes error like `java.io.FileNotFoundException: ./logs/application.log (No such file or directory)`.