### PR TITLE
Remodeling for puppet compliance and added Debian/Ubuntu support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,9 @@
+#Create configuration
 class cerebro::config (
-  $secret,
-  $hosts,
-  $basepath,
-) {
+  $secret = $cerebro::params::secret,
+  $hosts = $cerebro::params::hosts,
+  $basepath = $cerebro::params::basepath,
+) inherits cerebro::params {
   file { '/etc/cerebro/application.conf':
     content => template('cerebro/etc/cerebro/application.conf.erb'),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,21 +1,22 @@
+# Main class
 class cerebro (
-  $version        = '0.6.5',
-  $service_ensure = 'running',
-  $service_enable = true,
-  $secret         = 'ki:s:[[@=Ag?QI`W2jMwkY:eqvrJ]JqoJyi2axj3ZvOv^/KavOT4ViJSv?6YY4[N',
-  $hosts          = undef,
-  $basepath       = '/',
-) {
+  String $version        = $cerebro::params::version,
+  String $service_ensure = $cerebro::params::service_ensure,
+  String $service_enable = $cerebro::params::service_enable,
+  String $secret         = $cerebro::params::secret,
+  Array $hosts           = $cerebro::params::hosts,
+  String $basepath       = $cerebro::params::basepath,
+  String $user           = $cerebro::params::cerebro_user,
 
-  $cerebro_user = 'cerebro'
+) inherits cerebro::params {
 
   class { 'cerebro::user':
-    user => $cerebro_user,
+    cerebro_user  => $user,
   } ->
 
   class { 'cerebro::install':
-    user    => $cerebro_user,
-    version => $version,
+    cerebro_user => $user,
+    version      => $version,
   } ->
 
   class { 'cerebro::config':
@@ -25,7 +26,7 @@ class cerebro (
   } ~>
 
   class { 'cerebro::service':
-    enable => $service_enable,
-    ensure => $service_ensure,
+    service_enable => $service_enable,
+    service_ensure => $service_ensure,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,8 @@
 # Main class
 class cerebro (
   String $version        = $cerebro::params::version,
-  String $service_ensure = $cerebro::params::service_ensure,
-  String $service_enable = $cerebro::params::service_enable,
+  $service_ensure = $cerebro::params::service_ensure,
+  $service_enable = $cerebro::params::service_enable,
   String $secret         = $cerebro::params::secret,
   Array $hosts           = $cerebro::params::hosts,
   String $basepath       = $cerebro::params::basepath,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,9 +1,17 @@
+# Install Cerebro
 class cerebro::install (
-  $version,
-  $user,
-) {
-  $group = $user
-  $package_url = "https://github.com/lmenezes/cerebro/releases/download/v${version}/cerebro-${version}.zip"
+  $version        = $cerebro::params::version,
+  $service_ensure = $cerebro::params::service_ensure,
+  $service_enable = $cerebro::params::service_enable,
+  $secret         = $cerebro::params::secret,
+  $hosts          = $cerebro::params::hosts,
+  $basepath       = $cerebro::params::basepath,
+  $cerebro_user   = $cerebro::params::cerebro_user,
+  $package_url    = $cerebro::params::package_url,
+) inherits cerebro::params {
+
+  $group = $cerebro_user
+
 
   staging::deploy { "cerebro-${version}.zip":
     source => $package_url,
@@ -17,30 +25,30 @@ class cerebro::install (
 
   file { '/opt/cerebro/logs':
     ensure => 'directory',
-    owner  => $user,
+    owner  => $cerebro_user,
     group  => $group,
   } ->
 
   file { '/var/log/cerebro':
     ensure => 'link',
-    target => "/opt/cerebro/logs",
+    target => '/opt/cerebro/logs',
   }
 
   file { '/etc/cerebro':
     ensure => 'directory',
-    owner  => $user,
+    owner  => $cerebro_user,
     group  => $group,
   }
 
   file { '/var/cerebro':
     ensure => 'directory',
-    owner  => $user,
+    owner  => $cerebro_user,
     group  => $group,
   }
 
   file { '/var/run/cerebro':
     ensure => 'directory',
-    owner  => $user,
+    owner  => $cerebro_user,
     group  => $group,
   }
 
@@ -53,8 +61,9 @@ class cerebro::install (
   }
 
   exec { "systemd_reload_${title}":
-    command     => '/usr/bin/systemctl daemon-reload',
+    command     => 'systemctl daemon-reload',
     subscribe   => File['/etc/systemd/system/cerebro.service'],
     refreshonly => true,
+    path        => [ '/usr/local/sbin', '/usr/local/bin', '/usr/sbin', '/usr/bin', '/sbin', '/bin', '/snap/bin', '/snap/bin', '/opt/puppetlabs/bin' ],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,16 @@
+# Main class
+class cerebro::params {
+  $version        = '0.6.5'
+  $service_ensure = 'running'
+  $service_enable = true
+  $secret         = undef #Please specify a key
+  $hosts          = undef
+  $basepath       = '/'
+  $cerebro_user   = 'cerebro'
+  $package_url    = "https://github.com/lmenezes/cerebro/releases/download/v${version}/cerebro-${version}.zip"
+  if $facts[os][family] == 'Debian' {
+    $null_shell   = '/usr/sbin/nologin'
+  } else {
+    $null_shell   ='/sbin/nologin'
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,10 @@
+# Create the init script
 class cerebro::service (
-  $enable,
-  $ensure,
-) {
+  $service_ensure = $cerebro::params::service_ensure,
+  $service_enable = $cerebro::params::service_enable,
+) inherits cerebro::params {
   service { 'cerebro':
-    enable => $enable,
-    ensure => $ensure,
+    ensure => $service_ensure,
+    enable => $service_enable,
   }
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,8 +1,10 @@
+# Create the user to run services
 class cerebro::user (
-  $user,
-) {
-  user { $user:
+  $cerebro_user   = $cerebro::params::cerebro_user,
+  $null_shell     = $cerebro::params::null_shell,
+) inherits cerebro::params {
+  user { $cerebro_user:
     home  => '/opt/cerebro',
-    shell => '/sbin/nologin',
+    shell => $null_shell,
   }
 }

--- a/templates/etc/cerebro/application.conf.erb
+++ b/templates/etc/cerebro/application.conf.erb
@@ -11,6 +11,12 @@ hosts = [
   {
     host = "<%= host['host'] %>"
     name = "<%= host['name'] %>"
+    <% if host['auth'] == true  -%>
+    auth = {
+      username = "<%= host['username'] %>"
+      password = "<%= host['password'] %>"
+    }
+    <% end -%>
   },
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Hi,
I've made some changes.

- Remodeled the module to work with Debian and Ubuntu.
- Standardized adding the params.pp
- Added minimal comments
- Removed the standard key/secret
- Added authentication support to the application.conf
- Enforced variables type

Tried on:
- CentOS 7 
- Debian 8 
- Ubuntu 16.04

Hopefully didn't broke anything with older installation if at least secret was specified.