### PR TITLE
Use /etc/default to store sysconfig under Debian

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,12 +5,13 @@ class cerebro::config (
   $java_home           = $::cerebro::java_home,
   $java_opts           = $::cerebro::java_opts,
   $basic_auth_settings = $::cerebro::basic_auth_settings,
+  $sysconfig           = $::cerebro::sysconfig
 ) {
   file { '/etc/cerebro/application.conf':
     ensure  => file,
     content => template('cerebro/etc/cerebro/application.conf.erb'),
   }
-  file { '/etc/sysconfig/cerebro':
+  file { $sysconfig:
     ensure  => file,
     mode    => '0644',
     content => template('cerebro/etc/sysconfig/cerebro.erb'),

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,6 +2,7 @@ class cerebro::install (
   $version     = $::cerebro::version,
   $user        = $::cerebro::cerebro_user,
   $package_url = $::cerebro::package_url,
+  $sysconfig   = $::cerebro::sysconfig,
 ) {
   $group = $user
   $real_package_url = pick($package_url, "https://github.com/lmenezes/cerebro/releases/download/v${version}/cerebro-${version}.tgz")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,4 +14,8 @@ class cerebro::params {
   $java_opts      = []
   $java_home      = undef
   $basic_auth_settings = undef
+  $sysconfig = $::osfamily ? {
+    'Debian' => '/etc/default/cerebro',
+    default  => '/etc/sysconfig/cerebro',
+  }
 }

--- a/templates/etc/systemd/system/cerebro.service.erb
+++ b/templates/etc/systemd/system/cerebro.service.erb
@@ -7,7 +7,7 @@ WorkingDirectory=/opt/cerebro
 User=<%= @user %>
 Group=<%= @group %>
 PIDFile=/var/run/cerebro/cerebro.pid
-EnvironmentFile=-/etc/sysconfig/cerebro
+EnvironmentFile=-<%= @sysconfig %>
 ExecStart=/opt/cerebro/bin/cerebro -Dconfig.file=/etc/cerebro/application.conf
 ExecReload=/bin/kill -HUP $MAINPID
 SuccessExitStatus=143


### PR DESCRIPTION
A small fix to use `/etc/default/cerebro` to store the environment variable defaults under Debian-like systems. Fixes a failed install on an Ubuntu environment I was provisioning due to `/etc/sysconfig` not existing.