### PR TITLE
Allow opting out of user creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,19 +7,25 @@ class cerebro (
   $basepath            = $::cerebro::params::basepath,
   $shell               = $::cerebro::params::shell,
   $cerebro_user        = $::cerebro::params::cerebro_user,
+  $manage_user         = $::cerebro::params::manage_user,
   $package_url         = $::cerebro::params::package_url,
   $java_opts           = $::cerebro::params::java_opts,
   $java_home           = $::cerebro::params::java_home,
   $basic_auth_settings = $::cerebro::params::basic_auth_settings,
 ) inherits cerebro::params {
 
-  contain '::cerebro::user'
+  if $manage_user {
+    contain '::cerebro::user'
+
+    Class['cerebro::user']
+    -> Class['cerebro::install']
+  }
+
   contain '::cerebro::install'
   contain '::cerebro::config'
   contain '::cerebro::service'
 
-  Class['cerebro::user']
-  -> Class['cerebro::install']
+  Class['cerebro::install']
   -> Class['cerebro::config']
   ~> Class['cerebro::service']
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class cerebro::params {
   $hosts          = []
   $basepath       = '/'
   $cerebro_user   = 'cerebro'
+  $manage_user    = true
   $package_url    = undef
   $shell = $::osfamily ? {
     'Debian' => '/usr/sbin/nologin',


### PR DESCRIPTION
Some users will want to configure the cerebro user more than is available by default (just shell):

https://github.com/yano3/puppet-cerebro/blob/e6355f9f1f261f7365d8b1795fecfa8d80b8d1ef/manifests/user.pp#L5L8

A commonly-seen way to do this is for the module to allow the user to be managed elsewhere.