### PR TITLE
Update default cerebro version to v0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class { 'cerebro': }
 
 ```
 class { 'cerebro':
-  version => '0.7.1',
+  version => '0.7.2',
 }
 ```
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class cerebro::params {
-  $version        = '0.7.1'
+  $version        = '0.7.2'
   $service_ensure = 'running'
   $service_enable = true
   $secret         = cache_data('cerebro_cache_data', 'cerebro_secret', random_password(32))


### PR DESCRIPTION
Update default cerebro version to `v0.7.2`.