### PR TITLE
Add extraconfig parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class cerebro::config (
   $java_opts           = $::cerebro::java_opts,
   $basic_auth_settings = $::cerebro::basic_auth_settings,
   $sysconfig           = $::cerebro::sysconfig,
+  $extraconfig         = $::cerebro::extraconfig,
 ) {
   file { '/etc/cerebro/application.conf':
     ensure  => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class cerebro (
   $java_home           = $::cerebro::params::java_home,
   $basic_auth_settings = $::cerebro::params::basic_auth_settings,
   $address             = $::cerebro::params::address,
+  $extraconfig         = $::cerebro::params::extraconfig,
 ) inherits cerebro::params {
 
   if $manage_user {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,4 +20,5 @@ class cerebro::params {
     'Debian' => '/etc/default/cerebro',
     default  => '/etc/sysconfig/cerebro',
   }
+  $extraconfig    = undef
 }

--- a/templates/etc/cerebro/application.conf.erb
+++ b/templates/etc/cerebro/application.conf.erb
@@ -21,3 +21,6 @@ hosts = [
   },
 <% end -%>
 ]
+<% if @extraconfig -%>
+<%= @extraconfig %>
+<% end -%>


### PR DESCRIPTION
Needed a way to pass custom application.conf configuration data
from Hiera through this module, without having to fully understand
and implement every concievable setting that a user might want to set.

No requirement to use Hiera, you could use a long puppet string
or heredoc to set extraconfig in a manifest as well.

Resolves issue #33 using this block in my hiera data:

```
cerebro::extraconfig: |-2
  play.ws.ssl {
    trustManager = {
      stores = [
        { type = "PEM", path = "/etc/elasticsearch/elastic-ca.crt" }
      ]
    }
  }
```