### PR TITLE
Fix version number in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "yano3-cerebro",
-  "version": "0.1.10",
+  "version": "0.1.9",
   "author": "yano3",
   "summary": "Module for managing and configuring Cerebro",
   "license": "MIT",


### PR DESCRIPTION
Fix version number in metadata to follow current behavior of `module:release` task in puppet-blacksmith.